### PR TITLE
Fix a crash when parsing empty files

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -22,5 +22,5 @@ Yardstick::Rake::Measurement.new(:yardstick_measure) do |measurement|
 end
 
 Yardstick::Rake::Verify.new do |verify|
-  verify.threshold = 91.6
+  verify.threshold = 91.9
 end

--- a/lib/xliff/file.rb
+++ b/lib/xliff/file.rb
@@ -114,8 +114,8 @@ module Xliff
         datatype: xml['datatype'] || nil
       )
 
-      xml.at('header').element_children.each { |node| file.add_header Header.from_xml(node) }
-      xml.at('body').element_children.each { |node| file.add_entry Entry.from_xml(node) }
+      import_file_header(xml, file)
+      import_file_body(xml, file)
 
       file
     end
@@ -127,8 +127,37 @@ module Xliff
     # @raise [ExceptionClass] Raises exceptions if the input XML does not match expectations.
     # @return [void]
     def self.validate_source_xml(xml)
-      raise if xml.nil?
+      raise 'File XML is nil' if xml.nil?
+      raise "Invalid File XML – must be a nokogiri object, got `#{xml.class}`" unless xml.is_a? Nokogiri::XML::Element
       raise 'Invalid File XML – the root node must be `<file>`' if xml.name != 'file'
+    end
+
+    # Import File Header Tags from given XML
+    #
+    # Parses the `<header>` XML tag and imports any headers into the file.
+    #
+    # @api private
+    # @param [Nokogiri::XML::Element, #read] xml An XLIFF `<file>` fragment.
+    # @param [File] file The {File} object being created.
+    # @return [void]
+    private_class_method def self.import_file_header(xml, file)
+      return if xml.at('header').nil?
+
+      xml.at('header').element_children.each { |node| file.add_header Header.from_xml(node) }
+    end
+
+    # Import File <trans-unit> Tags from given XML
+    #
+    # Parses the `<body>` XML tag and imports any translation entries into the file.
+    #
+    # @api private
+    # @param [Nokogiri::XML::Element, #read] xml An XLIFF `<file>` fragment.
+    # @param [File] file The {File} object being created.
+    # @return [void]
+    private_class_method def self.import_file_body(xml, file)
+      return if xml.at('body').nil?
+
+      xml.at('body').element_children.each { |node| file.add_entry Entry.from_xml(node) }
     end
 
     private

--- a/spec/samples/fragment-empty-file.xml
+++ b/spec/samples/fragment-empty-file.xml
@@ -1,0 +1,1 @@
+<file original="Resources/en.lproj/InfoPlist.strings" source-language="en" target-language="en" datatype="plaintext" />

--- a/spec/samples/fragment-valid-file.xml
+++ b/spec/samples/fragment-valid-file.xml
@@ -1,0 +1,12 @@
+<file original="Resources/en.lproj/InfoPlist.strings" source-language="en" target-language="fr" datatype="plaintext">
+  <header>
+    <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="13.2.1" build-num="13C100"/>
+  </header>
+  <body>
+    <trans-unit id="hello-world" xml:space="preserve">
+      <source>hello</source>
+      <target>bonjoir</target>
+      <note>a friendly greeting</note>
+    </trans-unit>
+  </body>
+</file>

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -20,19 +20,6 @@ RSpec.configure do |config|
   end
 end
 
-## YARD Documentation Coverage
-require 'yardstick/rake/measurement'
-
-Yardstick::Rake::Measurement.new(:yardstick_measure) do |measurement|
-  measurement.output = 'coverage/yard-coverage.txt'
-end
-
-require 'yardstick/rake/verify'
-
-Yardstick::Rake::Verify.new do |verify|
-  verify.threshold = 100
-end
-
 ## Test Helpers
 
 def parse_xml(xml)

--- a/spec/xliff/file_spec.rb
+++ b/spec/xliff/file_spec.rb
@@ -31,6 +31,48 @@ RSpec.describe Xliff::File do
     end
   end
 
+  describe '#from_xml' do
+    let(:valid_file) { described_class.from_xml(sample_file_xml('fragment-valid-file.xml')) }
+
+    it 'raises for nil xml' do
+      expect { described_class.from_xml(nil) }.to raise_exception 'File XML is nil'
+    end
+
+    it 'raises for the wrong kind of object' do
+      msg = 'Invalid File XML – must be a nokogiri object, got `String`'
+      expect { described_class.from_xml('<xml />') }.to raise_exception msg
+    end
+
+    it 'raises for invalid xml' do
+      exp = 'Invalid File XML – the root node must be `<file>`'
+      expect { described_class.from_xml(Nokogiri::XML('<xml />').document.root) }.to raise_exception exp
+    end
+
+    it 'parses the `original` correctly' do
+      expect(valid_file.original).to eq 'Resources/en.lproj/InfoPlist.strings'
+    end
+
+    it 'parses the `source-language` correctly' do
+      expect(valid_file.source_language).to eq 'en'
+    end
+
+    it 'parses the `target-language` correctly' do
+      expect(valid_file.target_language).to eq 'fr'
+    end
+
+    it 'parses the `datatype` correctly' do
+      expect(valid_file.datatype).to eq 'plaintext'
+    end
+
+    it 'correctly parses file with missing header tag' do
+      expect(described_class.from_xml(sample_file_xml('fragment-empty-file.xml')).headers).to be_empty
+    end
+
+    it 'correctly parses file with missing body tag' do
+      expect(described_class.from_xml(sample_file_xml('fragment-empty-file.xml')).entries).to be_empty
+    end
+  end
+
   describe '.to_xml' do
     it 'produces valid XML' do
       expect(new_file.to_xml).to be_a Nokogiri::XML::Element


### PR DESCRIPTION
Fixes a bug that prevents using `File#from_xml` on empty files.