### PR TITLE
Fix critical nokogiri alert

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    xliff (1.0.2)
+    xliff (1.0.3)
       nokogiri (~> 1.13)
 
 GEM
@@ -74,12 +74,14 @@ GEM
     kramdown-parser-gfm (1.1.0)
       kramdown (~> 2.0)
     language_server-protocol (3.17.0.3)
-    mini_portile2 (2.8.5)
+    mini_portile2 (2.8.9)
     multipart-post (2.3.0)
     nap (1.1.0)
     no_proxy_fix (0.1.2)
-    nokogiri (1.15.5)
+    nokogiri (1.19.3)
       mini_portile2 (~> 2.8.2)
+      racc (~> 1.4)
+    nokogiri (1.19.3-x86_64-darwin)
       racc (~> 1.4)
     octokit (4.25.1)
       faraday (>= 1, < 3)
@@ -90,7 +92,7 @@ GEM
       ast (~> 2.4.1)
       racc
     public_suffix (5.0.4)
-    racc (1.7.3)
+    racc (1.8.1)
     rainbow (3.1.1)
     rake (13.1.0)
     rchardet (1.8.0)
@@ -174,4 +176,4 @@ DEPENDENCIES
   yardstick (~> 0.9.9)
 
 BUNDLED WITH
-   2.3.9
+   2.4.10


### PR DESCRIPTION
## Summary
- Refreshes Gemfile.lock so nokogiri resolves to 1.19.3.
- Clears the critical libxml2 advisory path in the Ruby dependency lockfile.

## Testing
- Dockerized Ruby 3.2.2 bundle install, nokogiri version check, and RSpec suite.
- 76 RSpec examples passed.
- git diff --check