### PR TITLE
Require Ruby 3.2 and normalize Gemfile.lock platforms

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 2.7.4
+  TargetRubyVersion: 3.2
   NewCops: enable
 
 # Don't fail for having too many tests

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -64,7 +64,21 @@ GEM
     nokogiri (1.19.3)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
+    nokogiri (1.19.3-aarch64-linux-gnu)
+      racc (~> 1.4)
+    nokogiri (1.19.3-aarch64-linux-musl)
+      racc (~> 1.4)
+    nokogiri (1.19.3-arm-linux-gnu)
+      racc (~> 1.4)
+    nokogiri (1.19.3-arm-linux-musl)
+      racc (~> 1.4)
+    nokogiri (1.19.3-arm64-darwin)
+      racc (~> 1.4)
     nokogiri (1.19.3-x86_64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.19.3-x86_64-linux-gnu)
+      racc (~> 1.4)
+    nokogiri (1.19.3-x86_64-linux-musl)
       racc (~> 1.4)
     octokit (10.0.0)
       faraday (>= 1, < 3)
@@ -141,9 +155,15 @@ GEM
       yard (~> 0.8, >= 0.8.7.2)
 
 PLATFORMS
+  aarch64-linux-gnu
+  aarch64-linux-musl
+  arm-linux-gnu
+  arm-linux-musl
+  arm64-darwin
   ruby
-  x86_64-darwin-19
-  x86_64-darwin-20
+  x86_64-darwin
+  x86_64-linux-gnu
+  x86_64-linux-musl
 
 DEPENDENCIES
   danger (~> 9.6)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     xliff (1.0.3)
-      nokogiri (~> 1.13)
+      nokogiri (~> 1.19)
 
 GEM
   remote: https://rubygems.org/

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -40,17 +40,17 @@ end
 
 def new_entry(id: 'id', source: 'source', target: 'target', note: nil)
   Xliff::Entry.new(
-    id: id,
-    source: source,
-    target: target,
-    note: note
+    id:,
+    source:,
+    target:,
+    note:
   )
 end
 
 def new_header(element: 'header', attributes: { foo: 'bar' })
   Xliff::Header.new(
-    element: element,
-    attributes: attributes
+    element:,
+    attributes:
   )
 end
 
@@ -62,10 +62,10 @@ def new_file(
   entries: []
 )
   file = Xliff::File.new(
-    original: original,
-    source_language: source_language,
-    target_language: target_language,
-    datatype: datatype
+    original:,
+    source_language:,
+    target_language:,
+    datatype:
   )
 
   entries.each { |e| file.add_entry(e) }

--- a/xliff.gemspec
+++ b/xliff.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |spec|
   spec.description = 'Read and write xliff files'
   spec.homepage = 'https://github.com/automattic/xliff'
   spec.license = 'MIT'
-  spec.required_ruby_version = '>= 2.7.4'
+  spec.required_ruby_version = '>= 3.2'
 
   # spec.metadata["allowed_push_host"] = "TODO: Set to your gem server 'https://example.com'"
 

--- a/xliff.gemspec
+++ b/xliff.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   # Uncomment to register a new dependency of your gem
-  spec.add_dependency 'nokogiri', '~> 1.13'
+  spec.add_dependency 'nokogiri', '~> 1.19'
 
   # For more information and examples about making a new gem, check out our
   # guide at: https://bundler.io/guides/creating_gem.html


### PR DESCRIPTION
## Summary
- Raise `required_ruby_version` to `>= 3.2` so the gemspec matches nokogiri 1.19.x (landed in #14), which dropped Ruby < 3.2.
- Normalize `Gemfile.lock` platforms (review comment in #14, r3335464288): drop the legacy `x86_64-darwin-19/20` entries.
- **No version bump** — the gem stays 1.0.3.

## Background
#14 bumped nokogiri to 1.19.3 to clear the libxml2 advisory, but left two loose ends:
1. The gemspec still declared `required_ruby_version = '>= 2.7.4'`, while nokogiri 1.19.x requires Ruby 3.2+. `.ruby-version` (3.2.2) and the CI image already require 3.2, so consumers on Ruby < 3.2 silently resolve `nokogiri ~> 1.13` down to the unpatched 1.15.x line.
2. The lockfile carried stale, OS-versioned darwin platforms (`x86_64-darwin-19/20`) and no Linux platforms.

## Changes
- **xliff.gemspec**: `required_ruby_version` `>= 2.7.4` → `>= 3.2`.
- **.rubocop.yml**: `TargetRubyVersion` `2.7.4` → `3.2`. RuboCop's `Gemspec/RequiredRubyVersion` cop requires this to equal the gemspec floor.
- **Gemfile.lock**: `bundle lock --normalize-platforms`. For nokogiri 1.19.x this replaces `x86_64-darwin-19/20` with `x86_64-darwin` + `arm64-darwin` and adds the gnu/musl split Linux gems. `BUNDLED WITH` held at 2.4.10 (the CI image's bundler); the lockfile round-trips under 2.4.10 with no churn.

## Note on the platform comment
The comment also suggested `bundle lock --add-platform x86_64-linux aarch64-linux`. With a modern Bundler that step is redundant and counter-productive — nokogiri 1.19.x ships **gnu/musl split** Linux gems, so `--add-platform` layers generic `x86_64-linux`/`aarch64-linux` names on top with no matching gem. `--normalize-platforms` alone produces the correct set.

To actually *use* the precompiled Linux gems on CI (instead of compiling nokogiri from source), CI's Bundler needs to be ≥ 2.5.6 — the `ruby:3.2.2` image ships 2.4.10. That's a separate, optional change to `.buildkite/pipeline.yml`; CI stays green either way (it source-compiles today).

## Test plan
- [x] CI green
- [x] `bundle _2.4.10_ lock` round-trips the lockfile with no churn (verified locally)
- [x] gemspec loads with `required_ruby_version >= 3.2`

## Related
- Follows #14; addresses review comment r3335464288.
