### PR TITLE
Configure Ruby Dependabot routing

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,11 @@
+# Ruby dependency surface
+Gemfile*              @Automattic/apps-infra-tooling
+*.gemspec             @Automattic/apps-infra-tooling
+.rubocop*.yml         @Automattic/apps-infra-tooling
+
+# CI and automation
+.buildkite/           @Automattic/apps-infra-tooling
+.github/dependabot.yml @Automattic/apps-infra-tooling
+
+# Toolchain and environment pins
+.ruby-version         @Automattic/apps-infra-tooling

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: bundler
+    directory: /
+    schedule:
+      interval: daily
+    groups:
+      ruby-minor-and-patch:
+        update-types: [minor, patch]
+    open-pull-requests-limit: 5


### PR DESCRIPTION
## Summary

Configures daily Dependabot updates for Ruby dependencies and routes the Ruby/gem/tooling/CI surface to `@Automattic/apps-infra-tooling` via CODEOWNERS. GitHub retired Dependabot's `reviewers` key, so routing now goes through CODEOWNERS.

## Testing

- Parsed `.github/dependabot.yml` and verified the campaign contract: one bundler entry, daily schedule, `ruby-minor-and-patch` grouping, open PR limit 5, and no `reviewers` key.
- Ran `git diff --check`.

Generated by Codex (GPT-5) on behalf of @mokagio.